### PR TITLE
fix: Remove redundant permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,6 @@
   },
 
   "permissions": [
-    "activeTab",
     "storage"
   ],
 


### PR DESCRIPTION
As per chrome's store feedback. activeTab Permission and all URLs match serve the same purpose. So, as a quick fix, removing activeTab since it's not used.